### PR TITLE
test(web): add vitest and testing library setup

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run"
   },
   "dependencies": {
     "next": "16.2.3",
@@ -15,11 +16,15 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "jsdom": "^29.0.2",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.4"
   },
   "ignoreScripts": [
     "sharp",

--- a/apps/web/tests/page.test.tsx
+++ b/apps/web/tests/page.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react";
+import Home from "../src/app/page";
+
+describe("Home page", () => {
+  it("renders the starter heading", () => {
+    render(<Home />);
+    expect(
+      screen.getByText(/to get started, edit the page\.tsx file\./i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: "./vitest.setup.ts",
+  },
+});

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";


### PR DESCRIPTION
Adds frontend test setup with Vitest and Testing Library, including a smoke test for the app router homepage.