### PR TITLE
feat(accounts): add account admin configuration and tests

### DIFF
--- a/apps/api/accounts/admin.py
+++ b/apps/api/accounts/admin.py
@@ -1,9 +1,17 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 
-from accounts.models import User
+from accounts.models import Profile, User
 
 
 @admin.register(User)
 class CustomUserAdmin(UserAdmin):  # type: ignore[type-arg]
-    pass
+    list_display = ("username", "email", "is_staff", "is_active")
+    search_fields = ("username", "email")
+
+
+@admin.register(Profile)
+class ProfileAdmin(admin.ModelAdmin):  # type: ignore[type-arg]
+    list_display = ("id", "user", "display_name", "created_at")
+    search_fields = ("display_name", "user__username", "user__email")
+    raw_id_fields = ("user",)

--- a/apps/api/accounts/tests/test_admin.py
+++ b/apps/api/accounts/tests/test_admin.py
@@ -1,0 +1,30 @@
+import pytest
+from django.contrib import admin
+
+from accounts.models import Profile, User
+
+
+@pytest.mark.django_db
+def test_user_is_registered_in_admin() -> None:
+    assert User in admin.site._registry
+
+
+@pytest.mark.django_db
+def test_profile_is_registered_in_admin() -> None:
+    assert Profile in admin.site._registry
+
+
+@pytest.mark.django_db
+def test_user_admin_configuration() -> None:
+    user_admin = admin.site._registry[User]
+
+    assert "email" in user_admin.list_display
+    assert "email" in user_admin.search_fields
+
+
+@pytest.mark.django_db
+def test_profile_admin_configuration() -> None:
+    profile_admin = admin.site._registry[Profile]
+
+    assert "display_name" in profile_admin.list_display
+    assert "user__email" in profile_admin.search_fields


### PR DESCRIPTION
Closes #320

## Scope
- register Profile in Django admin
- improve User admin configuration
- add admin tests for accounts

## Validation
- uv run ruff check .
- uv run mypy .
- uv run pytest --ds=config.settings.test