### PR TITLE
feat(cms): install and configure Wagtail

### DIFF
--- a/apps/api/config/settings/base.py
+++ b/apps/api/config/settings/base.py
@@ -19,6 +19,19 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "taggit",
+    "modelcluster",
+    "wagtail.contrib.forms",
+    "wagtail.contrib.redirects",
+    "wagtail.embeds",
+    "wagtail.sites",
+    "wagtail.users",
+    "wagtail.snippets",
+    "wagtail.documents",
+    "wagtail.images",
+    "wagtail.search",
+    "wagtail.admin",
+    "wagtail",
     "rest_framework",
     "core",
     "accounts",
@@ -33,16 +46,19 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.LoginRequiredMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "wagtail.contrib.redirects.middleware.RedirectMiddleware",
     "core.middleware.TimingMiddleware",
     "core.middleware.RequestIDMiddleware",
     "core.middleware.CSPMiddleware",
 ]
 
-LOGIN_URL = "/api/auth/login/"
-
-
 # Custom user model
 AUTH_USER_MODEL = "accounts.User"
+LOGIN_URL = "/api/auth/login/"
+
+# Wagtail settings
+WAGTAIL_SITE_NAME = "Nordic Stage"
+WAGTAILADMIN_BASE_URL = "http://localhost:8000/admin"
 
 # Content Security Policy (CSP) - Native Django 6.0+
 SECURE_CONTENT_SECURITY_POLICY = (

--- a/apps/api/config/urls.py
+++ b/apps/api/config/urls.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
+    path("django-admin/", admin.site.urls),
+    path("admin/", include("wagtail.admin.urls")),
+    path("documents/", include("wagtail.documents.urls")),
 ]

--- a/apps/api/core/tests/test_wagtail_setup.py
+++ b/apps/api/core/tests/test_wagtail_setup.py
@@ -1,0 +1,12 @@
+import pytest
+from django.urls import Resolver404, resolve
+
+
+def test_wagtail_admin_login_url_resolves() -> None:
+    match = resolve("/admin/login/")
+    assert match is not None
+
+
+def test_wagtail_documents_root_does_not_resolve() -> None:
+    with pytest.raises(Resolver404):
+        resolve("/documents/")


### PR DESCRIPTION
Closes #341

## Scope
- configure Wagtail in Django settings
- add Wagtail admin and documents URLs
- add Wagtail setup tests

## Notes
- using latest stable published Wagtail release
- no page models or CMS content yet

## Validation
- uv run ruff check .
- uv run mypy .
- uv run pytest --ds=config.settings.test
- uv run python manage.py check