### PR TITLE
feat(events): add Event managers

### DIFF
--- a/apps/api/events/models.py
+++ b/apps/api/events/models.py
@@ -1,12 +1,38 @@
-from typing import ClassVar
+from typing import ClassVar, Self
 
 from django.db import models
+from django.db.models import functions
 
 from core.models import BaseDomainModel
 
 
+class EventQuerySet(models.QuerySet["Event"]):
+    def published(self) -> Self:
+        return self.filter(is_published=True)
+
+    def upcoming(self) -> Self:
+        return self.filter(start_at__gte=functions.Now())
+
+    def past(self) -> Self:
+        return self.filter(end_at__lt=functions.Now())
+
+
+class EventManager(models.Manager["Event"]):
+    def get_queryset(self) -> EventQuerySet:
+        return EventQuerySet(self.model, using=self._db)
+
+    def published(self) -> EventQuerySet:
+        return self.get_queryset().published()
+
+    def upcoming(self) -> EventQuerySet:
+        return self.get_queryset().upcoming()
+
+    def past(self) -> EventQuerySet:
+        return self.get_queryset().past()
+
+
 class Event(BaseDomainModel):
-    objects = models.Manager["Event"]()
+    objects: ClassVar[EventManager] = EventManager()
 
     name = models.CharField(max_length=255)
     slug = models.SlugField(max_length=255, unique=True)
@@ -38,6 +64,7 @@ class Venue(BaseDomainModel):
     def __str__(self) -> str:
         return self.name
 
+
 class Speaker(BaseDomainModel):
     objects: ClassVar[models.Manager["Speaker"]] = models.Manager()
 
@@ -54,6 +81,7 @@ class Speaker(BaseDomainModel):
     def __str__(self) -> str:
         return self.full_name
 
+
 class Session(BaseDomainModel):
     objects: ClassVar[models.Manager["Session"]] = models.Manager()
 
@@ -69,6 +97,7 @@ class Session(BaseDomainModel):
 
     def __str__(self) -> str:
         return self.title
+
 
 class Tag(BaseDomainModel):
     objects: ClassVar[models.Manager["Tag"]] = models.Manager()

--- a/apps/api/events/tests/test_event_managers.py
+++ b/apps/api/events/tests/test_event_managers.py
@@ -1,0 +1,74 @@
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from events.models import Event
+
+
+@pytest.mark.django_db
+def test_event_manager_published_returns_only_published_events() -> None:
+    now = timezone.now()
+
+    published_event = Event.objects.create(
+        name="Published Event",
+        slug="published-event",
+        start_at=now,
+        end_at=now + timedelta(hours=1),
+        is_published=True,
+    )
+    Event.objects.create(
+        name="Draft Event",
+        slug="draft-event",
+        start_at=now,
+        end_at=now + timedelta(hours=1),
+        is_published=False,
+    )
+
+    events = Event.objects.published()
+
+    assert list(events) == [published_event]
+
+
+@pytest.mark.django_db
+def test_event_manager_upcoming_returns_only_future_events() -> None:
+    now = timezone.now()
+
+    upcoming_event = Event.objects.create(
+        name="Upcoming Event",
+        slug="upcoming-event",
+        start_at=now + timedelta(days=1),
+        end_at=now + timedelta(days=1, hours=1),
+    )
+    Event.objects.create(
+        name="Past Event",
+        slug="past-event",
+        start_at=now - timedelta(days=2),
+        end_at=now - timedelta(days=2, hours=-1),
+    )
+
+    events = Event.objects.upcoming()
+
+    assert list(events) == [upcoming_event]
+
+
+@pytest.mark.django_db
+def test_event_manager_past_returns_only_finished_events() -> None:
+    now = timezone.now()
+
+    past_event = Event.objects.create(
+        name="Past Event",
+        slug="past-event-2",
+        start_at=now - timedelta(days=2),
+        end_at=now - timedelta(days=1),
+    )
+    Event.objects.create(
+        name="Upcoming Event",
+        slug="upcoming-event-2",
+        start_at=now + timedelta(days=1),
+        end_at=now + timedelta(days=1, hours=1),
+    )
+
+    events = Event.objects.past()
+
+    assert list(events) == [past_event]


### PR DESCRIPTION
Closes #326

## Scope
- add Event queryset and manager methods
- add tests for published, upcoming, and past events

## Notes
- no selectors, services, or admin yet

## Validation
- uv run ruff check .
- uv run mypy .
- uv run pytest --ds=config.settings.test
- uv run python manage.py check