### PR TITLE
feat(events): add Event admin configuration and tests

### DIFF
--- a/apps/api/events/admin.py
+++ b/apps/api/events/admin.py
@@ -1,2 +1,19 @@
+from django.contrib import admin
 
-# Register your models here.
+from events.models import Event
+
+
+@admin.register(Event)
+class EventAdmin(admin.ModelAdmin[Event]):
+    list_display = (
+        "name",
+        "slug",
+        "start_at",
+        "end_at",
+        "is_published",
+        "created_at",
+    )
+    search_fields = ("name", "slug", "description")
+    list_filter = ("is_published", "created_at", "updated_at")
+    prepopulated_fields = {"slug": ("name",)}
+    ordering = ("start_at",)

--- a/apps/api/events/tests/test_admin.py
+++ b/apps/api/events/tests/test_admin.py
@@ -1,0 +1,21 @@
+import pytest
+from django.contrib import admin
+
+from events.models import Event
+
+
+@pytest.mark.django_db
+def test_event_is_registered_in_admin() -> None:
+    assert Event in admin.site._registry
+
+
+@pytest.mark.django_db
+def test_event_admin_configuration() -> None:
+    event_admin = admin.site._registry[Event]
+
+    assert "name" in event_admin.list_display
+    assert "slug" in event_admin.list_display
+    assert "is_published" in event_admin.list_display
+    assert "name" in event_admin.search_fields
+    assert "is_published" in event_admin.list_filter
+    assert event_admin.prepopulated_fields == {"slug": ("name",)}


### PR DESCRIPTION
Closes #329

## Scope
- register Event in Django admin
- add Event admin configuration
- add admin tests

## Notes
- Django admin only
- no CMS or Wagtail admin work

## Validation
- uv run ruff check .
- uv run mypy .
- uv run pytest --ds=config.settings.test
- uv run python manage.py check