### PR TITLE
feat(events): add Registration services

### DIFF
--- a/apps/api/events/services.py
+++ b/apps/api/events/services.py
@@ -1,7 +1,8 @@
 from datetime import datetime
+from typing import Any
 
 from core.services import BaseService
-from events.models import Event
+from events.models import Event, Registration
 
 
 class CreateEventService(BaseService):
@@ -65,3 +66,31 @@ class UpdateEventService(BaseService):
         self.event.save()
 
         return self.event
+
+class RegistrationService(BaseService):
+    def create_registration(
+        self,
+        *,
+        event: Event,
+        email: str,
+        full_name: str,
+        status: str = "pending",
+    ) -> Registration:
+        return Registration.objects.create(
+            event=event,
+            email=email,
+            full_name=full_name,
+            status=status,
+        )
+
+    def update_registration(
+        self,
+        *,
+        registration: Registration,
+        **kwargs: Any,
+    ) -> Registration:
+        for field, value in kwargs.items():
+            setattr(registration, field, value)
+
+        registration.save()
+        return registration

--- a/apps/api/events/tests/test_registration_services.py
+++ b/apps/api/events/tests/test_registration_services.py
@@ -1,0 +1,108 @@
+import pytest
+from django.db import IntegrityError
+from django.utils import timezone
+
+from events.models import Event, Registration
+from events.services import RegistrationService
+
+
+def create_event() -> Event:
+    now = timezone.now()
+    return Event.objects.create(
+        name="Nordic Stage 2026",
+        slug="nordic-stage-2026",
+        start_at=now,
+        end_at=now,
+    )
+
+
+@pytest.mark.django_db
+def test_create_registration_service_creates_registration() -> None:
+    service = RegistrationService()
+    event = create_event()
+
+    registration = service.create_registration(
+        event=event,
+        email="ada@example.com",
+        full_name="Ada Lovelace",
+    )
+
+    assert registration.event == event
+    assert registration.email == "ada@example.com"
+
+
+@pytest.mark.django_db
+def test_create_registration_service_raises_on_duplicate_email() -> None:
+    service = RegistrationService()
+    event = create_event()
+
+    service.create_registration(
+        event=event,
+        email="same@example.com",
+        full_name="First User",
+    )
+
+    with pytest.raises(IntegrityError):
+        service.create_registration(
+            event=event,
+            email="same@example.com",
+            full_name="Second User",
+        )
+
+
+@pytest.mark.django_db
+def test_update_registration_service_updates_fields() -> None:
+    service = RegistrationService()
+    event = create_event()
+
+    registration = service.create_registration(
+        event=event,
+        email="ada@example.com",
+        full_name="Ada Lovelace",
+    )
+
+    updated = service.update_registration(
+        registration=registration,
+        full_name="Ada L.",
+    )
+
+    assert updated.full_name == "Ada L."
+
+
+@pytest.mark.django_db
+def test_update_registration_service_persists_changes() -> None:
+    service = RegistrationService()
+    event = create_event()
+
+    registration = service.create_registration(
+        event=event,
+        email="persist@example.com",
+        full_name="Persistent User",
+    )
+
+    service.update_registration(
+        registration=registration,
+        full_name="Updated Name",
+    )
+
+    refreshed = Registration.objects.get(id=registration.id)
+    assert refreshed.full_name == "Updated Name"
+
+
+@pytest.mark.django_db
+def test_update_registration_does_not_create_new_instance() -> None:
+    service = RegistrationService()
+    event = create_event()
+
+    registration = service.create_registration(
+        event=event,
+        email="sameid@example.com",
+        full_name="Same ID",
+    )
+
+    updated = service.update_registration(
+        registration=registration,
+        full_name="Still Same ID",
+    )
+
+    assert updated.id == registration.id


### PR DESCRIPTION
Closes #334

## Scope
- add Registration service layer
- add Registration service tests

## Notes
- no ticket, payment, or waitlist promotion logic yet

## Validation
- uv run ruff check .
- uv run mypy .
- uv run pytest --ds=config.settings.test
- uv run python manage.py check