### PR TITLE
feat(events): add Order model and tests

### DIFF
--- a/apps/api/events/models.py
+++ b/apps/api/events/models.py
@@ -217,3 +217,32 @@ class Waitlist(BaseDomainModel):
 
     def __str__(self) -> str:
         return f"{self.full_name} - {self.event.name}"
+
+
+class OrderStatus(models.TextChoices):
+    PENDING = "pending", "Pending"
+    PAID = "paid", "Paid"
+    CANCELLED = "cancelled", "Cancelled"
+
+
+class Order(BaseDomainModel):
+    objects: ClassVar[models.Manager["Order"]] = models.Manager()
+
+    registration = models.OneToOneField(
+        Registration,
+        on_delete=models.CASCADE,
+        related_name="order",
+    )
+    amount = models.DecimalField(max_digits=10, decimal_places=2)
+    currency = models.CharField(max_length=3, default="EUR")
+    status = models.CharField(
+        max_length=20,
+        choices=OrderStatus.choices,
+        default=OrderStatus.PENDING,
+    )
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self) -> str:
+        return f"{self.registration.full_name} - {self.amount} {self.currency}"

--- a/apps/api/events/tests/test_order_models.py
+++ b/apps/api/events/tests/test_order_models.py
@@ -1,0 +1,134 @@
+import uuid
+from decimal import Decimal
+
+import pytest
+from django.db import IntegrityError
+from django.db.models import Manager
+from django.utils import timezone
+
+from events.models import Event, Order, OrderStatus, Registration
+
+
+def get_order_manager() -> Manager[Order]:
+    return Order._default_manager
+
+
+def create_event() -> Event:
+    now = timezone.now()
+    return Event.objects.create(
+        name="Nordic Stage 2026",
+        slug="nordic-stage-2026",
+        start_at=now,
+        end_at=now,
+    )
+
+
+def create_registration(email: str = "ada@example.com") -> Registration:
+    event = create_event()
+    return Registration.objects.create(
+        event=event,
+        email=email,
+        full_name="Ada Lovelace",
+    )
+
+
+@pytest.mark.django_db
+def test_order_can_be_created() -> None:
+    registration = create_registration()
+
+    order = get_order_manager().create(
+        registration=registration,
+        amount=Decimal("199.00"),
+        currency="EUR",
+    )
+
+    assert order.registration == registration
+    assert order.amount == Decimal("199.00")
+    assert order.currency == "EUR"
+    assert order.status == OrderStatus.PENDING
+
+
+@pytest.mark.django_db
+def test_order_id_is_uuid() -> None:
+    registration = create_registration()
+
+    order = get_order_manager().create(
+        registration=registration,
+        amount=Decimal("99.00"),
+        currency="EUR",
+    )
+
+    assert isinstance(order.id, uuid.UUID)
+
+
+@pytest.mark.django_db
+def test_order_has_timestamps() -> None:
+    registration = create_registration()
+
+    order = get_order_manager().create(
+        registration=registration,
+        amount=Decimal("49.00"),
+        currency="EUR",
+    )
+
+    assert order.created_at is not None
+    assert order.updated_at is not None
+
+
+@pytest.mark.django_db
+def test_order_string_representation() -> None:
+    registration = create_registration()
+
+    order = get_order_manager().create(
+        registration=registration,
+        amount=Decimal("149.00"),
+        currency="EUR",
+    )
+
+    assert str(order) == "Ada Lovelace - 149.00 EUR"
+
+
+@pytest.mark.django_db
+def test_order_is_unique_per_registration() -> None:
+    registration = create_registration()
+
+    get_order_manager().create(
+        registration=registration,
+        amount=Decimal("100.00"),
+        currency="EUR",
+    )
+
+    with pytest.raises(IntegrityError):
+        get_order_manager().create(
+            registration=registration,
+            amount=Decimal("200.00"),
+            currency="EUR",
+        )
+
+
+@pytest.mark.django_db
+def test_order_allows_different_orders_for_different_registrations() -> None:
+    first_registration = create_registration("first@example.com")
+    second_registration = Registration.objects.create(
+        event=Event.objects.create(
+            name="Nordic Stage 2027",
+            slug="nordic-stage-2027",
+            start_at=timezone.now(),
+            end_at=timezone.now(),
+        ),
+        email="second@example.com",
+        full_name="Grace Hopper",
+    )
+
+    get_order_manager().create(
+        registration=first_registration,
+        amount=Decimal("100.00"),
+        currency="EUR",
+    )
+    order = get_order_manager().create(
+        registration=second_registration,
+        amount=Decimal("200.00"),
+        currency="EUR",
+    )
+
+    assert order.registration == second_registration


### PR DESCRIPTION
Closes #336

## Scope
- add Order model to events app
- add Order model tests

## Notes
- no Stripe, webhook, or payment event logic yet

## Validation
- uv run ruff check .
- uv run mypy .
- uv run pytest --ds=config.settings.test
- uv run python manage.py check