### PR TITLE
feat(events): add Stripe gateway wrapper

### DIFF
--- a/apps/api/events/gateways.py
+++ b/apps/api/events/gateways.py
@@ -1,0 +1,41 @@
+from collections.abc import Mapping
+from typing import Any
+
+import stripe
+
+
+class StripeGateway:
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+        stripe.api_key = api_key
+
+    def create_checkout_session(
+        self,
+        *,
+        amount: int,
+        currency: str,
+        success_url: str,
+        cancel_url: str,
+        metadata: Mapping[str, str] | None = None,
+    ) -> Any:
+        return stripe.checkout.Session.create(
+            mode="payment",
+            line_items=[
+                {
+                    "price_data": {
+                        "currency": currency,
+                        "product_data": {
+                            "name": "Nordic Stage Registration",
+                        },
+                        "unit_amount": amount,
+                    },
+                    "quantity": 1,
+                }
+            ],
+            success_url=success_url,
+            cancel_url=cancel_url,
+            metadata=dict(metadata or {}),
+        )
+
+    def retrieve_event(self, event_id: str) -> Any:
+        return stripe.Event.retrieve(event_id)

--- a/apps/api/events/tests/test_stripe_gateway.py
+++ b/apps/api/events/tests/test_stripe_gateway.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from events.gateways import StripeGateway
+
+
+def test_stripe_gateway_sets_api_key() -> None:
+    gateway = StripeGateway(api_key="sk_test_123")
+
+    assert gateway.api_key == "sk_test_123"
+
+
+@patch("events.gateways.stripe.checkout.Session.create")
+def test_create_checkout_session_calls_stripe(mock_create: object) -> None:
+    mocked = mock_create
+    assert hasattr(mocked, "return_value")
+    mocked.return_value = SimpleNamespace(id="cs_test_123")
+
+    gateway = StripeGateway(api_key="sk_test_123")
+
+    session = gateway.create_checkout_session(
+        amount=19900,
+        currency="eur",
+        success_url="https://example.com/success",
+        cancel_url="https://example.com/cancel",
+        metadata={"order_id": "123"},
+    )
+
+    assert session.id == "cs_test_123"
+    mocked.assert_called_once()  # type: ignore[attr-defined]
+
+
+@patch("events.gateways.stripe.Event.retrieve")
+def test_retrieve_event_calls_stripe(mock_retrieve: object) -> None:
+    mocked = mock_retrieve
+    assert hasattr(mocked, "return_value")
+    mocked.return_value = SimpleNamespace(id="evt_123")
+
+    gateway = StripeGateway(api_key="sk_test_123")
+
+    event = gateway.retrieve_event("evt_123")
+
+    assert event.id == "evt_123"
+    mocked.assert_called_once_with("evt_123")  # type: ignore[attr-defined]


### PR DESCRIPTION
Closes #338

## Scope
- add Stripe gateway wrapper
- add gateway tests

## Notes
- thin adapter only
- no payment orchestration or webhook handling yet

## Validation
- uv run ruff check .
- uv run mypy .
- uv run pytest --ds=config.settings.test
- uv run python manage.py check