### PR TITLE
feat(events): add Stripe services

### DIFF
--- a/apps/api/events/services.py
+++ b/apps/api/events/services.py
@@ -2,7 +2,14 @@ from datetime import datetime
 from typing import Any
 
 from core.services import BaseService
-from events.models import Event, Registration
+from events.gateways import StripeGateway
+from events.models import (
+    Event,
+    Order,
+    PaymentEvent,
+    PaymentEventType,
+    Registration,
+)
 
 
 class CreateEventService(BaseService):
@@ -67,6 +74,7 @@ class UpdateEventService(BaseService):
 
         return self.event
 
+
 class RegistrationService(BaseService):
     def create_registration(
         self,
@@ -94,3 +102,38 @@ class RegistrationService(BaseService):
 
         registration.save()
         return registration
+
+
+class CreateStripeCheckoutSessionService(BaseService):
+    def __init__(
+        self,
+        *,
+        order: Order,
+        gateway: StripeGateway,
+        success_url: str,
+        cancel_url: str,
+    ) -> None:
+        super().__init__()
+        self.order = order
+        self.gateway = gateway
+        self.success_url = success_url
+        self.cancel_url = cancel_url
+
+    def execute(self) -> Any:
+        session = self.gateway.create_checkout_session(
+            amount=int(self.order.amount * 100),
+            currency=self.order.currency.lower(),
+            success_url=self.success_url,
+            cancel_url=self.cancel_url,
+            metadata={"order_id": str(self.order.id)},
+        )
+
+        PaymentEvent.objects.create(
+            order=self.order,
+            event_type=PaymentEventType.CREATED,
+            provider="stripe",
+            provider_event_id=getattr(session, "id", ""),
+            payload={"checkout_session_id": getattr(session, "id", "")},
+        )
+
+        return session

--- a/apps/api/events/tests/test_stripe_services.py
+++ b/apps/api/events/tests/test_stripe_services.py
@@ -1,0 +1,83 @@
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from django.utils import timezone
+
+from events.models import (
+    Event,
+    Order,
+    PaymentEvent,
+    PaymentEventType,
+    Registration,
+)
+from events.services import CreateStripeCheckoutSessionService
+
+
+def create_order() -> Order:
+    now = timezone.now()
+    event = Event.objects.create(
+        name="Nordic Stage 2026",
+        slug="nordic-stage-2026",
+        start_at=now,
+        end_at=now,
+    )
+    registration = Registration.objects.create(
+        event=event,
+        email="ada@example.com",
+        full_name="Ada Lovelace",
+    )
+    return Order.objects.create(
+        registration=registration,
+        amount=Decimal("199.00"),
+        currency="EUR",
+    )
+
+
+@pytest.mark.django_db
+def test_create_stripe_checkout_session_service_calls_gateway() -> None:
+    order = create_order()
+    gateway = MagicMock()
+    gateway.create_checkout_session.return_value = SimpleNamespace(
+        id="cs_test_123"
+    )
+
+    session = CreateStripeCheckoutSessionService(
+        order=order,
+        gateway=gateway,
+        success_url="https://example.com/success",
+        cancel_url="https://example.com/cancel",
+    ).process()
+
+    assert session.id == "cs_test_123"
+    gateway.create_checkout_session.assert_called_once_with(
+        amount=19900,
+        currency="eur",
+        success_url="https://example.com/success",
+        cancel_url="https://example.com/cancel",
+        metadata={"order_id": str(order.id)},
+    )
+
+
+@pytest.mark.django_db
+def test_create_stripe_checkout_session_service_logs_payment_event() -> None:
+    order = create_order()
+    gateway = MagicMock()
+    gateway.create_checkout_session.return_value = SimpleNamespace(
+        id="cs_test_456"
+    )
+
+    CreateStripeCheckoutSessionService(
+        order=order,
+        gateway=gateway,
+        success_url="https://example.com/success",
+        cancel_url="https://example.com/cancel",
+    ).process()
+
+    payment_event = PaymentEvent.objects.get(order=order)
+
+    assert payment_event.event_type == PaymentEventType.CREATED
+    assert payment_event.provider == "stripe"
+    assert payment_event.provider_event_id == "cs_test_456"
+    assert payment_event.payload == {"checkout_session_id": "cs_test_456"}


### PR DESCRIPTION
Closes #339

## Scope
- add Stripe checkout session service
- log payment events from Stripe service
- add service tests

## Notes
- no webhook handling yet
- no async processing yet

## Validation
- uv run ruff check .
- uv run mypy .
- uv run pytest --ds=config.settings.test
- uv run python manage.py check