### PR TITLE
test(events): harden payment flow coverage

### DIFF
--- a/apps/api/events/tests/test_payment_event_models.py
+++ b/apps/api/events/tests/test_payment_event_models.py
@@ -111,3 +111,4 @@ def test_payment_event_payload_defaults_to_empty_dict() -> None:
     )
 
     assert payment_event.payload == {}
+

--- a/apps/api/events/tests/test_stripe_gateway.py
+++ b/apps/api/events/tests/test_stripe_gateway.py
@@ -42,3 +42,24 @@ def test_retrieve_event_calls_stripe(mock_retrieve: object) -> None:
 
     assert event.id == "evt_123"
     mocked.assert_called_once_with("evt_123")  # type: ignore[attr-defined]
+
+@patch("events.gateways.stripe.checkout.Session.create")
+def test_create_checkout_session_defaults_metadata_to_empty_dict(
+    mock_create: object,
+) -> None:
+    mocked = mock_create
+    assert hasattr(mocked, "return_value")
+    mocked.return_value = SimpleNamespace(id="cs_test_999")
+
+    gateway = StripeGateway(api_key="sk_test_123")
+
+    gateway.create_checkout_session(
+        amount=5000,
+        currency="eur",
+        success_url="https://example.com/success",
+        cancel_url="https://example.com/cancel",
+    )
+
+    mocked.assert_called_once()  # type: ignore[attr-defined]
+    kwargs = mocked.call_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["metadata"] == {}

--- a/apps/api/events/tests/test_stripe_services.py
+++ b/apps/api/events/tests/test_stripe_services.py
@@ -81,3 +81,41 @@ def test_create_stripe_checkout_session_service_logs_payment_event() -> None:
     assert payment_event.provider == "stripe"
     assert payment_event.provider_event_id == "cs_test_456"
     assert payment_event.payload == {"checkout_session_id": "cs_test_456"}
+
+@pytest.mark.django_db
+def test_create_stripe_checkout_session_service_converts_amount_to_minor_units(
+) -> None:
+    order = create_order()
+    gateway = MagicMock()
+    session = SimpleNamespace(id="cs_test_minor")
+    gateway.create_checkout_session.return_value = session
+
+    CreateStripeCheckoutSessionService(
+        order=order,
+        gateway=gateway,
+        success_url="https://example.com/success",
+        cancel_url="https://example.com/cancel",
+    ).process()
+
+    gateway.create_checkout_session.assert_called_once()
+    kwargs = gateway.create_checkout_session.call_args.kwargs
+    assert kwargs["amount"] == 19900
+
+
+@pytest.mark.django_db
+def test_create_stripe_checkout_session_service_creates_single_payment_event(
+) -> None:
+    order = create_order()
+    gateway = MagicMock()
+    gateway.create_checkout_session.return_value = SimpleNamespace(
+        id="cs_test_single"
+    )
+
+    CreateStripeCheckoutSessionService(
+        order=order,
+        gateway=gateway,
+        success_url="https://example.com/success",
+        cancel_url="https://example.com/cancel",
+    ).process()
+
+    assert PaymentEvent.objects.filter(order=order).count() == 1


### PR DESCRIPTION
Closes #340

## Scope
- add payment edge case tests
- harden gateway and Stripe service coverage

## Notes
- no new architecture
- no webhook handling added

## Validation
- uv run ruff check .
- uv run mypy .
- uv run pytest --ds=config.settings.test
- uv run python manage.py check